### PR TITLE
Fix conditional in doDumps(z) that prevents dumping in different directions

### DIFF
--- a/dig.lua
+++ b/dig.lua
@@ -124,7 +124,7 @@ function doDump(z)
     blockCount = blockCount - 1
     end --if
 
-    if blockCount <= 0 then
+    if blockCount > 0 then
     if z == "fwd" then
       turtle.drop()
     elseif z == "down" then


### PR DESCRIPTION
Fix conditional in doDumps() that prevents dumping in different directions.